### PR TITLE
Implement Google OAuth frontend flow

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -1,2 +1,3 @@
 # Copy to .env.production and replace with your deployed backend URL
 VITE_API_BASE_URL=https://your-backend-url.a.run.app
+VITE_GOOGLE_OAUTH_ENABLED=false

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -79,4 +79,4 @@ jobs:
             --platform managed \
             --allow-unauthenticated \
             --port 8080 \
-            --set-env-vars "VITE_API_BASE_URL=${{ secrets.VITE_API_BASE_URL }}"
+            --set-env-vars "VITE_API_BASE_URL=${{ secrets.VITE_API_BASE_URL }},VITE_GOOGLE_OAUTH_ENABLED=true"

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ coverage
 npm-debug.log*
 .DS_Store
 key.json
+.env.local

--- a/src/AppRoutes.tsx
+++ b/src/AppRoutes.tsx
@@ -3,12 +3,14 @@ import { SummarizerPage } from '@/features/summarizer/SummarizerPage';
 import { UVAdvisorPage } from '@/features/uvAdvisor/UVAdvisorPage';
 import { SmartFAQPage } from '@/features/smartFaq/SmartFAQPage';
 import { AuthPage } from '@/features/auth/AuthPage';
+import { OAuthCallbackPage } from '@/features/auth/OAuthCallbackPage';
 import { ProtectedRoute } from '@/features/auth/components/ProtectedRoute';
 import { UploadAskPage } from '@/features/uploadAsk/UploadAskPage';
 
 export const AppRoutes = () => (
   <Routes>
     <Route path="/login" element={<AuthPage />} />
+    <Route path="/oauth/callback" element={<OAuthCallbackPage />} />
     <Route
       path="/"
       element={

--- a/src/features/auth/AuthPage.tsx
+++ b/src/features/auth/AuthPage.tsx
@@ -1,8 +1,9 @@
 import { FormEvent, useMemo, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { useServices } from '@/providers/ServiceProvider';
 import { useAuth } from '@/providers/AuthProvider';
 import { createAuthApi } from './api';
+import { loadEnv } from '@/utils/env';
 
 type Mode = 'login' | 'register';
 
@@ -17,11 +18,17 @@ export const AuthPage = () => {
   const api = useMemo(() => createAuthApi(httpClient), [httpClient]);
   const { login } = useAuth();
   const navigate = useNavigate();
+  const location = useLocation();
+  const env = loadEnv();
 
   const [mode, setMode] = useState<Mode>('login');
   const [form, setForm] = useState(initialState);
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const [isRedirecting, setIsRedirecting] = useState(false);
+  const [error, setError] = useState<string | null>(() => {
+    const state = location.state as { oauthError?: string } | null;
+    return state?.oauthError ?? null;
+  });
   const [message, setMessage] = useState<string | null>(null);
 
   const handleChange = (field: keyof typeof initialState) => (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -54,12 +61,28 @@ export const AuthPage = () => {
       }
       const response = await api.login({ email: form.email, password: form.password });
       login(response.token, response.refreshToken, response.user.email, response.user.nickname);
-      navigate('/', { replace: true });
+      const state = location.state as { from?: { pathname?: string } } | null;
+      const nextPath = state?.from?.pathname ?? '/';
+      navigate(nextPath, { replace: true });
     } catch (submitError) {
       setError((submitError as Error).message);
     } finally {
       setIsSubmitting(false);
     }
+  };
+
+  const handleGoogleLogin = () => {
+    setError(null);
+    setMessage(null);
+    setIsRedirecting(true);
+    const state = location.state as { from?: { pathname?: string } } | null;
+    const nextPath = state?.from?.pathname ?? '/';
+    sessionStorage.setItem('oauthReturnPath', nextPath);
+    const base = env.apiBaseUrl;
+    const loginUrl = base
+      ? `${base.replace(/\/$/, '')}/api/v1/auth/google/login`
+      : '/api/v1/auth/google/login';
+    window.location.assign(loginUrl);
   };
 
   return (
@@ -96,6 +119,24 @@ export const AuthPage = () => {
         {message && (
           <div className="mb-4 rounded-md border border-emerald-200 bg-emerald-50 p-3 text-sm text-emerald-700">
             {message}
+          </div>
+        )}
+
+        {env.googleOauthEnabled && (
+          <div className="mb-4 space-y-3">
+            <button
+              type="button"
+              onClick={handleGoogleLogin}
+              disabled={isSubmitting || isRedirecting}
+              className="flex w-full items-center justify-center gap-2 rounded-lg border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              {isRedirecting ? 'Redirecting to Google...' : 'Continue with Google'}
+            </button>
+            <div className="flex items-center gap-3 text-xs uppercase text-slate-400">
+              <span className="h-px flex-1 bg-slate-200" />
+              or
+              <span className="h-px flex-1 bg-slate-200" />
+            </div>
           </div>
         )}
 

--- a/src/features/auth/OAuthCallbackPage.tsx
+++ b/src/features/auth/OAuthCallbackPage.tsx
@@ -1,0 +1,70 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { useAuth } from '@/providers/AuthProvider';
+
+const RETURN_PATH_KEY = 'oauthReturnPath';
+
+const readParams = (search: string, hash: string) => {
+  const searchParams = new URLSearchParams(search);
+  const hashParams = new URLSearchParams(hash.startsWith('#') ? hash.slice(1) : hash);
+  const getParam = (key: string) => searchParams.get(key) ?? hashParams.get(key);
+
+  return {
+    token: getParam('token') ?? '',
+    refreshToken: getParam('refreshToken') ?? '',
+    email: getParam('email') ?? '',
+    nickname: getParam('nickname') ?? '',
+    error: getParam('error') ?? '',
+  };
+};
+
+export const OAuthCallbackPage = () => {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const { login } = useAuth();
+  const [error, setError] = useState<string | null>(null);
+
+  const params = useMemo(() => readParams(location.search, location.hash), [location.hash, location.search]);
+
+  useEffect(() => {
+    if (params.error) {
+      navigate('/login', { replace: true, state: { oauthError: params.error } });
+      return;
+    }
+
+    if (!params.token || !params.refreshToken || !params.email || !params.nickname) {
+      setError('We could not complete the Google sign-in. Please try again.');
+      return;
+    }
+
+    login(params.token, params.refreshToken, params.email, params.nickname);
+    const nextPath = sessionStorage.getItem(RETURN_PATH_KEY) ?? '/';
+    sessionStorage.removeItem(RETURN_PATH_KEY);
+    navigate(nextPath, { replace: true });
+  }, [login, navigate, params]);
+
+  return (
+    <div className="mx-auto flex w-full max-w-lg flex-col items-center justify-center py-12">
+      <div className="w-full rounded-2xl border border-border bg-white p-8 text-center shadow-sm">
+        {error ? (
+          <>
+            <h2 className="text-xl font-semibold text-slate-900">Sign-in failed</h2>
+            <p className="mt-2 text-sm text-slate-600">{error}</p>
+            <button
+              type="button"
+              onClick={() => navigate('/login', { replace: true })}
+              className="mt-6 rounded-lg bg-primary px-4 py-2 text-sm font-semibold text-white transition hover:bg-primary/90"
+            >
+              Back to login
+            </button>
+          </>
+        ) : (
+          <>
+            <h2 className="text-xl font-semibold text-slate-900">Completing sign-in</h2>
+            <p className="mt-2 text-sm text-slate-600">Please wait while we finish signing you in.</p>
+          </>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -1,5 +1,6 @@
 interface AppEnv {
   apiBaseUrl: string;
+  googleOauthEnabled: boolean;
 }
 
 const resolveBaseUrl = (): string => {
@@ -17,4 +18,5 @@ const resolveBaseUrl = (): string => {
 
 export const loadEnv = (): AppEnv => ({
   apiBaseUrl: resolveBaseUrl(),
+  googleOauthEnabled: (import.meta?.env?.VITE_GOOGLE_OAUTH_ENABLED ?? '').toString().toLowerCase() === 'true',
 });

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -4,13 +4,13 @@ interface AppEnv {
 }
 
 const resolveBaseUrl = (): string => {
-  if (import.meta.env.DEV) {
-    return '';
-  }
-
   const explicit = import.meta?.env?.VITE_API_BASE_URL;
   if (typeof explicit === 'string' && explicit.length > 0) {
     return explicit;
+  }
+
+  if (import.meta.env.DEV) {
+    return '';
   }
 
   return '/api';


### PR DESCRIPTION
Implements the Google OAuth frontend flow per the design doc.

Changes:
- Add a gated "Continue with Google" button on the auth page.
- Add `/oauth/callback` to finalize the OAuth flow and persist the session.
- Add `VITE_GOOGLE_OAUTH_ENABLED` env flag.

Closes #3.
Refs #1.
